### PR TITLE
Adds rspec test example and fix some syntax with rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,29 @@
+# https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml
+LineLength:
+    Max: 140
+AndOr:
+  Enabled: false
+Documentation:
+  Enabled: false
+DefWithParentheses:
+  Enabled: false
+MethodDefParentheses:
+  Enabled: false
+DotPosition:
+  Enabled: false
+AllCops:
+  Include:
+    - Rakefile
+    - config.ru
+  Exclude:
+    - bin/**/*
+    - db/**/*
+    - docs/**/*
+    - spec/**/*
+    - config/**/*
+    - script/**/*
+    - vendor/**/*
+    - features/**/*
+    - unicorn.rb
+    - !ruby/regexp /old_and_unused\.rb$/
+  RunRailsCops: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'unicorn'
 gem 'shotgun'
+gem 'rspec'
+gem 'rack-test'
 
 gem 'capistrano'

--- a/app.rb
+++ b/app.rb
@@ -1,8 +1,7 @@
-require "rubygems"
-require "sinatra/base"
+require 'rubygems'
+require 'sinatra/base'
 
 class App < Sinatra::Base
-
   get '/' do
     'Hello, nginx and unicorn!'
   end

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,5 @@
-require "rubygems"
-require "sinatra"
+require 'rubygems'
+require 'sinatra'
 
 require File.expand_path '../app.rb', __FILE__
 

--- a/models/foo.rb
+++ b/models/foo.rb
@@ -1,0 +1,5 @@
+class Foo
+  def hello
+    "world"
+  end
+end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -1,0 +1,9 @@
+# spec/app_spec.rb
+require File.expand_path '../spec_helper.rb', __FILE__
+
+describe 'My Sinatra Application' do
+  it 'should allow accessing the home page' do
+    get '/'
+    expect { last_response.should be_ok }
+  end
+end

--- a/spec/foo_spec.rb
+++ b/spec/foo_spec.rb
@@ -1,0 +1,10 @@
+# spec/app_spec.rb
+require File.expand_path '../spec_helper.rb', __FILE__
+require File.expand_path '../../models/foo.rb', __FILE__
+
+describe 'Foo' do
+  it 'instantiate the method' do
+    foo = Foo.new
+    expect(foo.hello).to eql('world')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# spec/spec_helper.rb
+require 'rack/test'
+require 'rspec'
+
+require File.expand_path '../../app.rb', __FILE__
+
+ENV['RACK_ENV'] = 'test'
+
+module RSpecMixin
+  include Rack::Test::Methods
+  def app() App end
+end
+
+# For RSpec 2.x
+RSpec.configure { |c| c.include RSpecMixin }


### PR DESCRIPTION
I use this repo a lot to start with Sinatra projects, the thing I most miss is a built in RSpec integration, so I added it.

Bellow you can see a simple RSpec output.

It is based on a [sinatra recipe](http://recipes.sinatrarb.com/p/testing/rspec)

The last thing I added is one model, so we can test ruby classes and routes at the same time.

```bash
default-sinatra-app/ (master) λ rspec 

Randomized with seed 39996

Foo
  instantiate the method

My Sinatra Application
  should allow accessing the home page

Top 2 slowest examples (0.04119 seconds, 89.3% of total time):
  My Sinatra Application should allow accessing the home page
    0.04085 seconds ./spec/app_spec.rb:5
  Foo instantiate the method
    0.00034 seconds ./spec/foo_spec.rb:6

Top 2 slowest example groups:
  My Sinatra Application
    0.04085 seconds average (0.04085 seconds / 1 example) ./spec/app_spec.rb:4
  Foo
    0.00034 seconds average (0.00034 seconds / 1 example) ./spec/foo_spec.rb:5

Finished in 0.04611 seconds (files took 0.19652 seconds to load)
2 examples, 0 failures

Randomized with seed 39996
```